### PR TITLE
dummy path for dashboard to activate home page for build

### DIFF
--- a/client/src/App/App.jsx
+++ b/client/src/App/App.jsx
@@ -32,8 +32,9 @@ class App extends React.Component {
                         }
                         <Router history={history}>
                             <div>
-                                <PrivateRoute exact path="/" component={Dashboard} />
                                 <Route path="/" component={HomePage} />
+                                <PrivateRoute exact path="/123456" component={Dashboard} />
+
                                 <Route path="/login" component={LoginPage} />
                                 <Route path="/register" component={RegisterPage} />
                             </div>


### PR DESCRIPTION
added a place holder in the dashboard link path="/123456" we can't use "/" for two locations. We can converse before I or we make any other permanent changes to any paths.